### PR TITLE
Add the library badge for Mod Menu

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,6 +14,13 @@
   "mixins": [
     "worldmesher.mixins.json"
   ],
+  "custom": {
+    "modmenu": {
+      "badges": [
+        "library"
+      ]
+    }
+  },
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",


### PR DESCRIPTION
This pull request adds custom metadata to `fabric.mod.json` that Mod Menu uses to show the library badge in its mod list.