### PR TITLE
Fix crash when constructing Builder from BlockRenderView

### DIFF
--- a/src/main/java/io/wispforest/worldmesher/WorldMesh.java
+++ b/src/main/java/io/wispforest/worldmesher/WorldMesh.java
@@ -338,7 +338,7 @@ public class WorldMesh {
         }
 
         public Builder(BlockRenderView world, BlockPos origin, BlockPos end) {
-            this(world, origin, end, List::of);
+            this(world, origin, end, (except) -> List.of());
         }
 
         public Builder disableCulling() {


### PR DESCRIPTION
Made a grave mistake in my previous PR. I originally made `entitySupplier` a `Supplier` and not a `Function`, and used `List::of` to supply an empty list, however, a last-minute refactor allowed the "except" entity to be passed as a parameter. Long story short, I didn't catch the side effect of `List::of` now being given a parameter, which may be null if there's no world opened, causing an exception when initializing the list.