### PR TITLE
Prevent VBO leaks on the GPU, Optionally clear exising buffers on rebuild

### DIFF
--- a/src/main/java/io/wispforest/worldmesher/WorldMesh.java
+++ b/src/main/java/io/wispforest/worldmesher/WorldMesh.java
@@ -294,7 +294,9 @@ public class WorldMesh {
                 vertexBuffer.bind();
                 vertexBuffer.upload(bufferBuilder.end());
 
-                bufferStorage.put(renderLayer, vertexBuffer);
+                final var discardedBuffer = bufferStorage.put(renderLayer, vertexBuffer);
+                if (discardedBuffer != null)
+                    discardedBuffer.close();
             });
 
             future.complete(null);

--- a/src/main/java/io/wispforest/worldmesher/WorldMesh.java
+++ b/src/main/java/io/wispforest/worldmesher/WorldMesh.java
@@ -50,7 +50,6 @@ public class WorldMesh {
     private DynamicRenderInfo renderInfo;
     private boolean entitiesFrozen;
     private boolean freezeEntities;
-    private boolean clearBufferMap;
     private final Function<PlayerEntity, List<Entity>> entitySupplier;
 
     private final Runnable renderStartAction;
@@ -160,17 +159,10 @@ public class WorldMesh {
     /**
      * Schedules a rebuild of this mesh
      */
-
     public void scheduleRebuild() {
-        this.scheduleRebuild(false);
-    }
-
-    public void scheduleRebuild(boolean clearBuffers) {
         if (state.isBuildStage) return;
         state = state == MeshState.NEW ? MeshState.BUILDING : MeshState.REBUILDING;
         initializedLayers.clear();
-
-        this.clearBufferMap = clearBuffers;
 
         CompletableFuture.runAsync(this::build, Util.getMainWorkerExecutor()).whenComplete((unused, throwable) -> {
             if (throwable != null) {
@@ -283,10 +275,8 @@ public class WorldMesh {
 
         var future = new CompletableFuture<Void>();
         RenderSystem.recordRenderCall(() -> {
-            if (clearBufferMap) {
-                bufferStorage.forEach((renderLayer, vertexBuffer) -> vertexBuffer.close());
-                bufferStorage.clear();
-            }
+            bufferStorage.forEach((renderLayer, vertexBuffer) -> vertexBuffer.close());
+            bufferStorage.clear();
 
             initializedLayers.forEach((renderLayer, bufferBuilder) -> {
                 final var vertexBuffer = new VertexBuffer();


### PR DESCRIPTION
I found a situation where rebuilding a `WorldMesh` on a world that changes in a certain way between rebuilds can prevent exiting buffers from being reset. Specifically, if you render a set of blocks that use one render layer, delete those blocks, add new blocks which use a different render layer, and `scheduleRebuild`, the original blocks remain. That's a useful feature for deferred rendering, but I added an option to clear buffers anyway.

During testing I also found a couple of potential VBO leaks on the GPU and patched them.