### PR TITLE
Builder option to allow AO and culling neighbors to exist outside the render volume

### DIFF
--- a/src/main/java/io/wispforest/worldmesher/WorldMesh.java
+++ b/src/main/java/io/wispforest/worldmesher/WorldMesh.java
@@ -360,7 +360,7 @@ public class WorldMesh {
             return this;
         }
 
-        public Builder enableGlobalNeighbors() {
+        public Builder useGlobalNeighbors() {
             this.useGlobalNeighbors = true;
             return this;
         }


### PR DESCRIPTION
Useful for batching a large area into multiple meshes and rendering them as one, while maintaining uniform lighting and preventing unneeded faces from being drawn