### PR TITLE
Allow explicitly releasing WorldMesh buffers

### DIFF
--- a/src/main/java/io/wispforest/worldmesher/WorldMesh.java
+++ b/src/main/java/io/wispforest/worldmesher/WorldMesh.java
@@ -156,7 +156,12 @@ public class WorldMesh {
         return dimensions;
     }
 
-    public void reset() {
+    /**
+     * Release unmanaged vertex buffers and clear all initialized
+     * layers. Resulting mesh state is ready to accept new vertex
+     * data.
+     */
+    public void clear() {
         this.bufferStorage.forEach((renderLayer, vertexBuffer) -> vertexBuffer.close());
         this.bufferStorage.clear();
 

--- a/src/main/java/io/wispforest/worldmesher/WorldMesh.java
+++ b/src/main/java/io/wispforest/worldmesher/WorldMesh.java
@@ -156,6 +156,13 @@ public class WorldMesh {
         return dimensions;
     }
 
+    public void reset() {
+        this.bufferStorage.forEach((renderLayer, vertexBuffer) -> vertexBuffer.close());
+        this.bufferStorage.clear();
+
+        this.initializedLayers.clear();
+    }
+
     /**
      * Schedules a rebuild of this mesh
      */


### PR DESCRIPTION
Added the option to manually release the buffers in a `WorldMesh` to prevent GPU memory leaks in situations where you're generating and replacing many `WorldMesh` instances.