### PR TITLE
Entity rendering fixes.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ minecraft_version=1.20
 yarn_mappings=1.20+build.1
 loader_version=0.14.21
 # Mod Properties
-mod_version=0.3.0
+mod_version=0.4.0
 maven_group=io.wispforest
 archives_base_name=worldmesher
 # Dependencies


### PR DESCRIPTION
Fixes 2 main issues I found while using Isometric Renderer:
- Fixes usage of hashmap, so entities with same positions will render correctly (instead of rendering just single one).
- Make box used for entity collection take full space, making it catch small entities on the edges.

API is still backwards compatible, but ideally old one should be removed.
Tested with Isometric Renderer and it works™ without changes